### PR TITLE
chore: add npm publishing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This acts as a repo of guides and documents specific to the team, plus it's wher
 - [API examples](/api/README.md)
 - [Principles](principles.md)
 - [Ways of working](ways_of_working.md)
+- [Publishing NPM packages](/npm/publishing.md)
 
 ## Otherwise known as
 

--- a/npm/publishing.md
+++ b/npm/publishing.md
@@ -1,0 +1,35 @@
+# Publishing to NPM
+
+The [Water Abstraction Helpers](https://github.com/DEFRA/water-abstraction-helpers) repo is publsihed to npm: https://www.npmjs.com/package/@envage/water-abstraction-helpers.
+
+
+To publsih a pakcgae to npm:
+- Create a branch to make changes
+- Ensure the pipeline passes
+- Merge into master
+- Create a Release / Tag (This will trigger the release pipeline)
+
+The pipeline relies on a `WATER_NPM_TOKEN` to publish to npm which is held by the DEFRA organization. 
+
+```yml
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  # Test should have passed before this job is manually triggered
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.WATER_NPM_TOKEN}}
+```

--- a/npm/publishing.md
+++ b/npm/publishing.md
@@ -3,7 +3,7 @@
 The [Water Abstraction Helpers](https://github.com/DEFRA/water-abstraction-helpers) repo is publsihed to npm: https://www.npmjs.com/package/@envage/water-abstraction-helpers.
 
 
-To publsih a pakcgae to npm:
+To publish a package to npm:
 - Create a branch to make changes
 - Ensure the pipeline passes
 - Merge into master

--- a/npm/publishing.md
+++ b/npm/publishing.md
@@ -5,6 +5,7 @@ The [Water Abstraction Helpers](https://github.com/DEFRA/water-abstraction-helpe
 
 To publish a package to npm:
 - Create a branch to make changes
+- Manually Update the package.json version number (This will be the tag version aswell)
 - Ensure the pipeline passes
 - Merge into master
 - Create a Release / Tag (This will trigger the release pipeline)


### PR DESCRIPTION
Add advice on how to automate publishing to npm. 

Publishing to npm must have been done manually before. 

@jonathangoulding created this basic pipeline to automate the publishing to npm. 

No conventional commit automation is implemented so a manual package-version jump will be needed