### PR TITLE
Add exception to block body convention

### DIFF
--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -55,7 +55,9 @@ const helloWorld = () => {
 }
 ```
 
-When we do need to use arrow functions, parameters are always wrapped in brackets even if there is only one. Also, use _block body_ over _concise body_.
+### Arrow functions
+
+When we do need to use [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), parameters are always wrapped in brackets even if there is only one. Also, use _block body_ over _concise body_ *️⃣.
 
 ```javascript
 const materials = [
@@ -72,6 +74,25 @@ materials.forEach((material) => {
 
 // Do not use Concise body version
 materials.forEach((material) => console.log(`${material} - ${material.length}`))
+```
+
+#### *️⃣ The exception
+
+The one exception to _block_ body over _concise_ is when you are just performing a [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) check.
+
+```javascript
+const transactions = [
+  { billableDays: 25, volume: 100 },
+  { billableDays: 15, volume: 75, charge: 754 }
+]
+
+// Concise - It's clearer we only care if it's 'truthy'
+transactions.some((transaction) => transaction.charge)
+
+// Body - It looks like we care more about the value of charge
+transactions.some((transaction) => {
+  return transaction.charge
+})
 ```
 
 ## Top of .js files


### PR DESCRIPTION
This came out during the [PR that first added conventions](https://github.com/DEFRA/water-abstraction-team/pull/68) to our teams' repo.

As promised, this change adds details of the exception to the PR which is about when we should favour _concise_ body arrow functions over _block_ body.