### PR TITLE
Ad-hoc query for lic. with charge vers. in 2022

### DIFF
--- a/queries/lics_with_chg_vers_after_20220401.md
+++ b/queries/lics_with_chg_vers_after_20220401.md
@@ -35,7 +35,11 @@ SELECT
   -- The request was for Licence Type (full or transfer). However, we can't find any data that
   -- refers to a type of that has one of these values
   ('UNKNOWN') AS licence_type,
-  l.start_date,
+  (CASE
+    WHEN l.expired_date IS NOT NULL THEN l.expired_date
+    WHEN l.lapsed_date IS NOT NULL THEN l.lapsed_date
+    WHEN l.revoked_date IS NOT NULL THEN l.revoked_date
+  END) AS effective_end_date,
   bill_runs.bill_run_number,
   cp.is_section_127_agreement_enabled,
   cv.*

--- a/queries/lics_with_chg_vers_after_20220401.md
+++ b/queries/lics_with_chg_vers_after_20220401.md
@@ -58,17 +58,7 @@ SELECT
   (ce.adjustments->>'s130') AS adj_s130,
   (ce.adjustments->>'charge') AS adj_charge,
   (ce.adjustments->>'winter') AS adj_winter,
-  (ce.adjustments->>'aggregate') AS adj_aggregate,
-  cp.charge_purpose_id,
-  cp.description,
-  cp.abstraction_period_start_day,
-  cp.abstraction_period_start_month,
-  cp.abstraction_period_end_day,
-  cp.abstraction_period_end_month,
-  cp.authorised_annual_quantity,
-  cp.billable_annual_quantity,
-  cp.loss,
-  cp.is_section_127_agreement_enabled
+  (ce.adjustments->>'aggregate') AS adj_aggregate
 FROM water.licences l
 -- Some licences have special agreements linked to them. `financial_agreement_types` is the lookup table
 -- and `licence_agreements` is the join table. A licence can have multiple agreements but the request was
@@ -107,6 +97,6 @@ LEFT JOIN (
 INNER JOIN water.charge_versions cv ON cv.licence_id = l.licence_id
 INNER JOIN water.charge_elements ce ON ce.charge_version_id = cv.charge_version_id
 INNER JOIN water.billing_charge_categories bcc ON bcc.billing_charge_category_id = ce.billing_charge_category_id
-INNER JOIN water.charge_purposes cp ON cp.charge_element_id = ce.charge_element_id
 WHERE cv.start_date >= '2022-04-01'
+AND cv.status = 'current'
 ```

--- a/queries/lics_with_chg_vers_after_20220401.md
+++ b/queries/lics_with_chg_vers_after_20220401.md
@@ -1,0 +1,70 @@
+# Licences with charge versions created after 2022-04-01
+
+- **Business**
+- **2023-04-23**
+- [WATER-3901](https://eaflood.atlassian.net/browse/WATER-3901)
+
+> There are 3 reports in the service which are used to aid the business is calculating impact of changes to schemes and accruing any un-billed sums into the following Financial Year. Due to the timings of Supplementary Billing, we will need to accrue anything yet to be billed into the following year.
+>
+> There are 2 reports required, each can be provided as a data dump upon request from the Business, rather than needing full front end solutions.
+>
+> Report 1:
+>
+> For all licences (Live and Dead) with a confirmed charge version created on or after 1/4/2022 provide:
+>
+> - Licence Number
+> - Licence Status
+> - Licence Type (full or transfer)
+> - Effective end date if not live (revoked, lapsed or expired date)
+> - Detail 1 line per charge category (and or purpose) containing all fields from the the charge version
+> - Include additional field to show if an agreement is in effect
+> - Agreement type in effect (eg 2PT)
+> - Include Y/N field to show if the Annual Bill has been run for the licence
+
+## Query
+
+```sql
+SELECT
+  l.licence_ref,
+  (CASE
+    WHEN l.expired_date IS NOT NULL THEN 'expired'
+    WHEN l.lapsed_date IS NOT NULL THEN 'lapsed'
+    WHEN l.revoked_date IS NOT NULL THEN 'revoked'
+    ELSE 'current'
+  END) AS licence_status,
+  -- The request was for Licence Type (full or transfer). However, we can't find any data that
+  -- refers to a type of that has one of these values
+  ('UNKNOWN') AS licence_type,
+  l.start_date,
+  bill_runs.bill_run_number,
+  cp.is_section_127_agreement_enabled,
+  cv.*
+FROM water.licences l
+-- They need to know if the charge version has been included in an annual bill run this financial year.
+-- We create a derived table based on the billing data filtered by bill run type, status and financial year.
+-- We then link our licences to it
+LEFT JOIN (
+  SELECT
+    bil.licence_id,
+    bb.bill_run_number,
+    bb.batch_type,
+    bb.to_financial_year_ending,
+    bb.status
+  FROM water.billing_invoice_licences bil
+  INNER JOIN water.billing_invoices bi ON bi.billing_invoice_id = bil.billing_invoice_id
+  INNER JOIN water.billing_batches bb ON bb.billing_batch_id = bi.billing_batch_id
+  WHERE bb.to_financial_year_ending = 2023 AND bb.status = 'sent' AND bb.batch_type = 'annual'
+  GROUP BY bil.licence_id, bb.bill_run_number, bb.batch_type, bb.to_financial_year_ending, bb.status
+) bill_runs ON bill_runs.licence_id = l.licence_id
+-- A licence will have multiple charge versions. As changes are made a new charge version is created. However
+-- experience has shown us that the `status` field in the table cannot be trusted so we cannot just grab
+-- the one with a status of 'current'. So, we are left with grabbing whichever has the latest version number
+-- and using that to identify which charge version is 'current'
+INNER JOIN (
+  SELECT MAX(cv.version_number) AS latest_version, cv.licence_ref FROM water.charge_versions cv GROUP BY cv.licence_ref
+) latest_charge_version ON latest_charge_version.licence_ref = l.licence_ref
+INNER JOIN water.charge_versions cv ON (cv.licence_ref = latest_charge_version.licence_ref AND cv.version_number = latest_charge_version.latest_version)
+INNER JOIN water.charge_elements ce ON ce.charge_version_id = cv.charge_version_id
+INNER JOIN water.charge_purposes cp ON cp.charge_element_id = ce.charge_element_id
+WHERE cv.date_created >= '2022-04-01'
+```

--- a/queries/lics_with_chg_vers_after_20220401.md
+++ b/queries/lics_with_chg_vers_after_20220401.md
@@ -39,7 +39,8 @@ SELECT
   END) AS effective_end_date,
   bill_runs.bill_run_number,
   agreements.agreement_codes,
-  cv.*
+  bcc.reference,
+  ce.*
 FROM water.licences l
 -- They need to know if the charge version has been included in an annual bill run this financial year.
 -- We create a derived table based on the billing data filtered by bill run type, status and financial year.
@@ -84,6 +85,7 @@ INNER JOIN (
 ) latest_charge_version ON latest_charge_version.licence_ref = l.licence_ref
 INNER JOIN water.charge_versions cv ON (cv.licence_ref = latest_charge_version.licence_ref AND cv.version_number = latest_charge_version.latest_version)
 INNER JOIN water.charge_elements ce ON ce.charge_version_id = cv.charge_version_id
+INNER JOIN water.billing_charge_categories bcc ON bcc.billing_charge_category_id = ce.billing_charge_category_id
 INNER JOIN water.charge_purposes cp ON cp.charge_element_id = ce.charge_element_id
 WHERE cv.date_created >= '2022-04-01'
 ```


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3901

This is the first of 2 queries requested by the business to support the need to accrue due to the late delivery of SROC supplementary billing.

The request for the first report is

> [..] all licences (Live and Dead) with a confirmed charge version created on or after 1/4/2022 [..]

The data requested was

- Licence Number
- Licence Status
- Effective end date if not live (revoked, lapsed or expired date)
- Detail 1 line per charge category (and or purpose) containing all fields from the charge version
- Include additional field to show if an agreement is in effect
- Agreement type in effect (eg 2PT)
- Include Y/N field to show if the Annual Bill has been run for the licence

What we eventually built is not quite the same. We iterated the initial query a few times after feedback. But this was the genesis of the query.
