### PR TITLE
Alter 'Do this first' section in welcome guide

### DIFF
--- a/welcome.md
+++ b/welcome.md
@@ -125,12 +125,16 @@ So, we're afraid your first day or two is likely to be reading stuff or listenin
 
 ### Do this first
 
-On your brick track down the myIT portal and search for [CCOE Azure/AWS Non-Production Service Request](https://defragroup.service-now.com/esc?id=sc_cat_item&table=sc_cat_item&sys_id=cedac95b1b224510adf0eb53b24bcb63). Complete the form and submit the request (the current team will help you with this). This request will go to our fabulous friends on the AWS web-ops team who will then ensure you can access
+The team tech lead needs to submit a [CCOE Azure/AWS Non-Production Service Request](https://defragroup.service-now.com/esc?id=sc_cat_item&table=sc_cat_item&sys_id=cedac95b1b224510adf0eb53b24bcb63) on the **myIT** portal to ensure you have access to
 
 - our Jenkins instance
 - our GitLab instance
 - our environments via a VPN account they'll create for you
 - the AWS console for non-production logs
+
+This request will go to our fabulous friends on the AWS web-ops team who will get all this sorted for you.
+
+Feel free to ask whether they have remembered to do this!
 
 ## I have my Mac
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4243
https://eaflood.atlassian.net/browse/WATER-4244

We hastily threw the [welcome guide together](https://github.com/DEFRA/water-abstraction-team/pull/108) so we had something for some new starters to our team. When we wrote it we thought individuals themselves had to summit the `CCOE Azure/AWS Non-Production Service Request` to get access to non-prod environments and things like Jenkins and GitLab.

But having walked them through it we saw we can submit these requests on their behalf. Just as soon as we know they have a Defra email address we can get the requests in. It makes for a much slicker process.

So, we're altering this section so the call to action is on checking the tech lead has submitted the request rather than asking them to do it themselves. It means we can leave the details in so the tech lead has a chance of remembering what it is they are supposed to be doing!