### PR TITLE
Update information on background jobs post changes

### DIFF
--- a/jobs/README.md
+++ b/jobs/README.md
@@ -53,7 +53,6 @@ Using the information we have gathered about the background jobs running in the 
 |10:00|[Tracker](/jobs/import.md#tracker)|[water-abstraction-import](/jobs/import.md)|
 |11:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 |12:00|[Check for updated invoice accounts](/jobs/service.md#check-for-updated-invoice-accounts)|[water-abstraction-service](/jobs/service.md)|
-| -   |[Licence not in charge version workflow](/jobs/service.md#licence-not-in-charge-version-workflow)|[water-abstraction-service](/jobs/service.md)|
 | -   |[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 |13:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 |14:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
@@ -65,10 +64,8 @@ Using the information we have gathered about the background jobs running in the 
 |18:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 | -   |[Digitise To Licence Gauging Stations](/jobs/service.md#digitise-to-licence-gauging-stations)|[water-abstraction-service](/jobs/service.md)|
 | -   |[Digitise to Licence Version Purpose (LVP) Sync](/jobs/service.md#digitise-to-licence-version-purpose-lvp-sync)|[water-abstraction-service](/jobs/service.md)|
-| -   |[Licence not in charge version workflow](/jobs/service.md#licence-not-in-charge-version-workflow)|[water-abstraction-service](/jobs/service.md)|
 |19:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 |20:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
-|20:15|[Time limited](/jobs/system.md#time-limited)|[water-abstraction-system](/jobs/system.md)|
 |21:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 |22:00|[Charge Categories Sync](/jobs/service.md#charge-categories-sync)|[water-abstraction-service](/jobs/service.md)|
 | -   |[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
@@ -76,7 +73,6 @@ Using the information we have gathered about the background jobs running in the 
 |23:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 |00:00|[Check for updated invoice accounts](/jobs/service.md#check-for-updated-invoice-accounts)|[water-abstraction-service](/jobs/service.md)|
 | -   |[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
-| -   |[Licence not in charge version workflow](/jobs/service.md#licence-not-in-charge-version-workflow)|[water-abstraction-service](/jobs/service.md)|
 |01:00|[Charging import (data)](/jobs/import.md#charging-import-data)|[water-abstraction-import](/jobs/import.md)|
 | -   |[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 | -   |[NALD import](/jobs/import.md#nald-import)|[water-abstraction-import](/jobs/import.md)|
@@ -88,7 +84,8 @@ Using the information we have gathered about the background jobs running in the 
 | -   |[Licence import](/jobs/import.md#licence-import)|[water-abstraction-import](/jobs/import.md)|
 |05:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 |06:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
-| -   |[Licence not in charge version workflow](/jobs/service.md#licence-not-in-charge-version-workflow)|[water-abstraction-service](/jobs/service.md)|
 |07:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 |08:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
+|08:05|[Licence updates](/jobs/system.md#licence-updates)|[water-abstraction-system](/jobs/system.md)|
+|08:15|[Time limited](/jobs/system.md#time-limited)|[water-abstraction-system](/jobs/system.md)|
 |09:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|

--- a/jobs/service.md
+++ b/jobs/service.md
@@ -63,8 +63,6 @@ The jobs appear to be grouped by what they are related to.
   - [Charge Categories Sync](#charge-categories-sync)
   - [Check for updated invoice accounts](#check-for-updated-invoice-accounts)
   - [Customer file refresh](#customer-file-refresh)
-- Charge versions
-  - [Licence not in charge version workflow](#licence-not-in-charge-version-workflow)
 - Gauging stations
   - [Digitise To Licence Gauging Stations](#digitise-to-licence-gauging-stations)
   - [Digitise to Licence Version Purpose (LVP) Sync](#digitise-to-licence-version-purpose-lvp-sync)
@@ -146,13 +144,6 @@ We have no other details on this job other than what you can determine in `src/m
 There is a CSV file (`gauging-stations/gauging-stations.csv`) held in the `wabs3-maintenance` bucket which contains a list of gauging stations.
 
 Every 6 hours this job checks for changes and either inserts or updates the changes. It is also pointless for exactly the same reasons as [Charge Categories Sync](#charge-categories-sync)!
-
-### Licence not in charge version workflow
-
-- **request** N/A
-- **Schedule** Every 6th hour of the day (00:00, 06:00, 12:00, and 18:00)
-
-We _think_ this job looks for licences that do not have a charge version. For those it finds it creates a `water.charge_version_workflow` record. We as yet have had no need to interact with this table so we don't know what then happens with the information.
 
 ### Refresh event
 

--- a/jobs/system.md
+++ b/jobs/system.md
@@ -50,6 +50,8 @@ See [WATER-4437](https://eaflood.atlassian.net/browse/WATER-4437) for more detai
 ### Time limited
 
 - **request** `POST /jobs/time-limited`
-- **schedule** 20:15 every day
+- **schedule** 08:05 every day
 
-Puts SROC licences into 'workflow' that have a related `purpose` that is due to expire in less than 50 days. See [WATER-3486](https://eaflood.atlassian.net/browse/WATER-3486) for more details if needed.
+> We intentionally run this job before [Licence updates](#licence-updates). Should a licence with a time limited purpose get updated, highlighting it is time-limited takes precedence over it also being an updated licence
+
+Puts SROC licences into 'workflow' that have a related `purpose` that is due to expire in less than 50 days. You'll see them listed on the **Charge information workflow** 'To setup' tab with the action link `Time limited`. See [WATER-3486](https://eaflood.atlassian.net/browse/WATER-3486) for more details if needed.

--- a/jobs/system.md
+++ b/jobs/system.md
@@ -32,6 +32,21 @@ This is a fallback option should the overnight refresh of our DB to a read-only 
 
 These schema `.tgz` files are then uploaded to AWS S3 where they can de downloaded. This was built to support the reporting needs of the service. It is not currently scheduled in `production`.
 
+### Licence updates
+
+- **request** `POST /jobs/licence-updates`
+- **schedule** 08:15 every day
+
+> Replaced a job in the legacy [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service) which we had to replace when we found that BullMQ isn't reliably triggering scheduled jobs.
+
+For context, putting a licence into workflow is a current practice to prevent them being billed until the Billing & Data team have had a chance to confirm all is well.
+
+The job puts licences into 'workflow' that have a `licence_version` that was created in the last 2 months (from date the job is run). If the licence is already in 'workflow' or part of a PRESROC bill run it skips adding it. Hence, the 2 month window. This covers licences that, for example, were in a bill run that has now been 'sent', so can be added to workflow for checking.
+
+Essentially, the current logic is premised that there is a 1-to-1 relationship between `licence_version` and `charge_version_workflows` where `deleted_date` is not null! This is what stops a licence continually being added back into workflow.
+
+See [WATER-4437](https://eaflood.atlassian.net/browse/WATER-4437) for more details if needed.
+
 ### Time limited
 
 - **request** `POST /jobs/time-limited`


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4437

We have [recently migrated](https://github.com/DEFRA/water-abstraction-system/pull/903) the **Licence not in charge version workflow** job from the [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service) to a new job in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system).

Whilst we were at it we also arranged to get the [Time limited job](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/system.md#time-limited) scheduled in `production`.

This change updates our guides to reflect these changes.