### PR TITLE
Remove block-body exception from coding convention

### DIFF
--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -238,6 +238,7 @@ const ChargeModuleTokenService = require('../../app/services/charge-module-token
 
 // Start testing!
 ```
+
 ## JSDoc Comments
 
 In node the standard way to document code is by using comments called [JSDoc]( https://jsdoc.app/) comments. This style of comments has its own conventions that we follow.
@@ -249,6 +250,7 @@ Begin the JSDoc comment with a one-line short description of the code element, p
 Use the [@param](https://jsdoc.app/tags-param.html) and [@returns](https://jsdoc.app/tags-returns.html) tags to provide details on the arguments a method expects and what it returns.
 
 For example:
+
 - `@param {string} name - Name of the licensee` A simple primitive param
 - `@param {number[]} readings - Meter readings for the last week` A param that is an array
 - `@returns {Object} Details about the abstraction purpose` Documenting the return value
@@ -256,6 +258,7 @@ For example:
 We don't end the method short description or the param and return descriptions with a full stop. If an expanded description is added treat it as a normal document and do finish the sentences with full stops.
 
 The following is an example of a 'good' method document comment.
+
 ```javascript
 /**
  * Fetch all SROC charge versions linked to licences flagged for supplementary billing

--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -101,25 +101,6 @@ materials.forEach((material) => {
 materials.forEach((material) => console.log(`${material} - ${material.length}`))
 ```
 
-#### *️⃣ The exception
-
-The one exception to _block_ body over _concise_ is when you are just performing a [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) check.
-
-```javascript
-const transactions = [
-  { billableDays: 25, volume: 100 },
-  { billableDays: 15, volume: 75, charge: 754 }
-]
-
-// Concise - It's clearer we only care if it's 'truthy'
-transactions.some((transaction) => transaction.charge)
-
-// Body - It looks like we care more about the value of charge
-transactions.some((transaction) => {
-  return transaction.charge
-})
-```
-
 ### Function naming conventions for services
 
 The bulk of our system's business logic resides in "services", each of which typically performs a single task. This task may be an individual step of a process, or it may be marshalling the various steps of this multi-stage process. But either way, services tend to focus on doing one thing in particular.


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/115

We have been working on using ESLint to help highlight coding convention infractions instead of folks either having to remember them when submitting or reviewing PRs. In [Ensure use of block body for arrow functions](https://github.com/DEFRA/water-abstraction-system/pull/1006) we managed to figure out how to have the tool highlight when someone has used concise over block-body format for an arrow function.

However, the rule cannot distinguish between when it was being used normally, or just to check if something is 'truthy'. That was the one exception we had and there is no point in keeping it documented here if the tool won't allow it. We also didn't think it was worth the effort to try and 'hack' ESLint or develop a custom rule just to support this. On balance, it goes against one of our guiding principles of consistency anyway.

So, this change removes the exceptions from our docs.