### PR TITLE
Add coding convention for unit test descriptive text

### DIFF
--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -253,11 +253,16 @@ it('returns a "true" success status', async () => {
 })
 
 // Bad
+it('returns a \'true\' success status', async () => {
+  expect(succeeded).to.be.true()
+})
+
+// Also bad
 it('returns a `true` success status', async () => {
   expect(succeeded).to.be.true()
 })
 
-// Also Bad
+// Also bad
 it("returns a 'true' success status", async () => {
   expect(succeeded).to.be.true()
 })

--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -12,6 +12,7 @@ We make best efforts to follow them when working in the legacy repos. There are 
 - [Line length](#line-length)
 - [Top of .js files](#top-of-js-files)
   - [Top of test.js files](#top-of-testjs-files)
+- [Unit test descriptive text](#unit-test-descriptive-text)
 - [JSDoc Comments](#JSDoc-Comments)
   - [Promises](#promises)
 
@@ -237,6 +238,29 @@ const RequestLib = require('../../app/lib/request.lib.js')
 const ChargeModuleTokenService = require('../../app/services/charge-module-token.service.js')
 
 // Start testing!
+```
+
+## Unit test descriptive text
+
+When writing the descriptive text in either the `describe()` or `it()` blocks of a unit test, we follow the convention of wrapping the text in single quotes.
+
+If there is a word(s) within this text string that we want to emphasise then we follow the convention of wrapping the word(s) in double quotes.
+
+```javascript
+// Good
+it('returns a "true" success status', async () => {
+  expect(succeeded).to.be.true()
+})
+
+// Bad
+it('returns a `true` success status', async () => {
+  expect(succeeded).to.be.true()
+})
+
+// Also Bad
+it("returns a 'true' success status", async () => {
+  expect(succeeded).to.be.true()
+})
 ```
 
 ## JSDoc Comments


### PR DESCRIPTION
There has been some inconsistency in how words are being emphasised in the `describe()` or `it()` blocks of a unit test.

Following a discussion on our daily dev call we agreed on a standard where the descriptive text would always be wrapped in single quotes. If there is a word(s) within that text that we want to emphasise then this would be wrapped in double quotes.

This PR adds this convention to our coding conventions document.