### PR TITLE
Temporary session storage cleanup job

### DIFF
--- a/jobs/README.md
+++ b/jobs/README.md
@@ -67,6 +67,7 @@ Using the information we have gathered about the background jobs running in the 
 |19:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 |20:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 |21:00|[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
+|21:15|[Session cleanup](/jobs/system.md#session-cleanup)|[water-abstraction-system](/jobs/system.md)|
 |22:00|[Charge Categories Sync](/jobs/service.md#charge-categories-sync)|[water-abstraction-service](/jobs/service.md)|
 | -   |[Customer file refresh](/jobs/service.md#customer-file-refresh)|[water-abstraction-service](/jobs/service.md)|
 | -   |[Gauging Stations Sync](/jobs/service.md#gauging-stations-sync)|[water-abstraction-service](/jobs/service.md)|

--- a/jobs/system.md
+++ b/jobs/system.md
@@ -47,6 +47,13 @@ Essentially, the current logic is premised that there is a 1-to-1 relationship b
 
 See [WATER-4437](https://eaflood.atlassian.net/browse/WATER-4437) for more details if needed.
 
+### Session cleanup
+
+- **request** `POST /jobs/session-cleanup`
+- **schedule** 21:15 every day
+
+Deletes any records from the `public.sessions` table that are over 24hrs old. See [WATER-4281](https://eaflood.atlassian.net/browse/WATER-4281) for more details if needed.
+
 ### Time limited
 
 - **request** `POST /jobs/time-limited`


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4281

As part of the work on returns, we have had to build in support for temporary session storage into the `water-abstraction-system`. This is what allows us to track data across pages as part of a journey until it’s ready to be properly persisted.

A job has now been created that can be triggered through an API call that deletes any record in sessions where the created on date is more than 24 hours ago.

This PR is going to add details of that job to our documentation.