### PR TITLE
Update coding conventions to include pageTitle and navBar

### DIFF
--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -336,7 +336,6 @@ The `pageTitle` should always be set in the presenter.
 
 This ensures that the `pageTitle` is dynamically generated alongside other data being worked out in the presenter. By centralizing this logic in the presenter, we avoid duplication in the services, and maintain a single source of truth for dynamic page titles.
 
----
 
 ### Active NavBar
 
@@ -344,7 +343,6 @@ The `activeNavBar` should always be set in the service that is called from the c
 
 Keeping the `activeNavBar` in the service reduces the logic in controllers.
 
----
 
 ### Controller Implementation
 

--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -378,7 +378,7 @@ async function go(id) {
   }
 }
 ```
-Note: We prefer to name the data fetched from the presenter as formattedData to clearly indicate that it has been
+Note: We prefer to name the data fetched from the presenter as `formattedData` to clearly indicate that it has been
 processed and formatted for use in the view.
 
 ### Bad Example

--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -15,6 +15,7 @@ We make best efforts to follow them when working in the legacy repos. There are 
 - [Unit test descriptive text](#unit-test-descriptive-text)
 - [JSDoc Comments](#JSDoc-Comments)
   - [Promises](#promises)
+- [Page Title and Active NavBar Logic](#page-title-and-active-navbar-logic)
 
 ## Add the .js extension
 
@@ -321,4 +322,57 @@ The 'good' example demonstrates how to document the Promise.
  * @returns {Promise<Object[]>} An array of matching charge versions
  */
 async function go (regionId, billingPeriod) {
+```
+## Page Title and Active NavBar Logic
+
+When working with pageTitle and activeNavBar, we follow the following conventions to maintain consistency and keep our code clean.
+
+## Page Titles
+
+The `pageTitle` should always be set in the presenter.
+
+This ensures that the `pageTitle` is dynamically generated alongside other data being worked out in the presenter. By centralizing this logic in the presenter, we avoid duplication in the services, and maintain a single source of truth for dynamic page titles.
+
+---
+
+## Active Nav Bar
+
+The `activeNavBar` should always be set in the service that is called from the controller.
+
+Keeping the `activeNavBar` in the service reduces the logic in controllers.
+
+---
+
+## Controller Implementation
+
+Controllers should always return the view using the `pageData` object, which includes both the `pageTitle` and the `activeNavBar`, as well as any other required data.
+
+### Good Example
+
+The following example demonstrates the correct usage of `pageTitle` and `activeNavBar`:
+
+```javascript
+async function reported(request, h) {
+  const { licenceId } = request.params
+  const pageData = await ReportedService.go(licenceId)
+
+  return h.view('return-logs/setup/reported.njk', pageData)
+}
+```
+
+### Bad Example
+
+The following example demonstrates the wrong usage of `pageTitle` and `activeNavBar`:
+
+```javascript
+async function reported(request, h) {
+  const { licenceId } = request.params
+  const pageData = await ReportedService.go(licenceId)
+
+  return h.view('return-logs/setup/reported.njk', {
+    pageTitle: 'How was this return reported?',
+    activeNavBar: 'search',
+    ...pageData
+  })
+}
 ```

--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -16,6 +16,9 @@ We make best efforts to follow them when working in the legacy repos. There are 
 - [JSDoc Comments](#JSDoc-Comments)
   - [Promises](#promises)
 - [Page Title and Active NavBar Logic](#page-title-and-active-navbar-logic)
+  - [Page Titles](#page-titles)
+  - [Active NavBar](#active-navbar)
+  - [Controller Implementation](#controller-implementation)
 
 ## Add the .js extension
 
@@ -327,7 +330,7 @@ async function go (regionId, billingPeriod) {
 
 When working with pageTitle and activeNavBar, we follow the following conventions to maintain consistency and keep our code clean.
 
-## Page Titles
+### Page Titles
 
 The `pageTitle` should always be set in the presenter.
 
@@ -335,7 +338,7 @@ This ensures that the `pageTitle` is dynamically generated alongside other data 
 
 ---
 
-## Active Nav Bar
+### Active NavBar
 
 The `activeNavBar` should always be set in the service that is called from the controller.
 
@@ -343,7 +346,7 @@ Keeping the `activeNavBar` in the service reduces the logic in controllers.
 
 ---
 
-## Controller Implementation
+### Controller Implementation
 
 Controllers should always return the view using the `pageData` object, which includes both the `pageTitle` and the `activeNavBar`, as well as any other required data.
 

--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -359,9 +359,7 @@ The `activeNavBar` should always be set in the service that is called from the c
 
 Keeping the `activeNavBar` in the service reduces the logic in controllers.
 
-The following example demonstrates the correct way the service should return data, when that data is being used to
-render a view. In this case, the `activeNavBar` is explicitly set within the service, while other data is handled and
-returned through the presenter:
+The following example demonstrates the correct way the service should return data, when that data is being used to render a view. In this case, the `activeNavBar` is explicitly set within the service, while other data is handled and returned through the presenter:
 
 ```javascript
 async function go(id) {
@@ -375,12 +373,9 @@ async function go(id) {
 }
 ```
 
-Note: We prefer to name the data fetched from the presenter as `formattedData` to clearly indicate that it has been
-processed and formatted for use in the view.
+Note: We prefer to name the data fetched from the presenter as `formattedData` to clearly indicate that it has been processed and formatted for use in the view.
 
-The following example demonstrates the wrong way the service could return.  Notice that the presenter is returning
-`pageData` instead of `formattedData`. Additionally, the `pageTitle` is being returned from the service, whereas it
-should be returned by the presenter.
+The following example demonstrates the wrong way the service could return.  Notice that the presenter is returning `pageData` instead of `formattedData`. Additionally, the `pageTitle` is being returned from the service, whereas it should be returned by the presenter.
 
 ```javascript
 async function go(id) {

--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -328,7 +328,7 @@ async function go (regionId, billingPeriod) {
 ```
 ## Page Title and Active NavBar Logic
 
-When working with pageTitle and activeNavBar, we follow the following conventions to maintain consistency and keep our code clean.
+When working with `pageTitle` and `activeNavBar`, we follow the following conventions to maintain consistency and keep our code clean.
 
 ### Page Titles
 

--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -334,7 +334,7 @@ When working with pageTitle and activeNavBar, we follow the following convention
 
 The `pageTitle` should always be set in the presenter.
 
-This ensures that the `pageTitle` is dynamically generated alongside other data being worked out in the presenter. By centralizing this logic in the presenter, we avoid duplication in the services, and maintain a single source of truth for dynamic page titles.
+This ensures that the `pageTitle` is dynamically generated alongside other data being worked out in the presenter. By centralising this logic in the presenter, we avoid duplication in the services, and maintain a single source of truth for dynamic page titles.
 
 
 ### Active NavBar

--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -13,7 +13,7 @@ We make best efforts to follow them when working in the legacy repos. There are 
 - [Top of .js files](#top-of-js-files)
   - [Top of test.js files](#top-of-testjs-files)
 - [Unit test descriptive text](#unit-test-descriptive-text)
-- [JSDoc Comments](#JSDoc-Comments)
+- [JSDoc Comments](#jsdoc-comments)
   - [Promises](#promises)
 - [Page Title and Active NavBar Logic](#page-title-and-active-navbar-logic)
   - [Page Titles](#page-titles)
@@ -51,7 +51,6 @@ Other naming conventions are
 To ensure cross-platform compatibility file names should always be written in lower case. This includes the use of acronyms in the file name. For example `convert-to-csv.service.js`.
 
 Unit test files should be the same as the thing being tested with `.test` added to the end, for example `thing.service.test.js`. The `test/` folder structure should mirror the `app/` folder.
-
 
 ## Modules
 
@@ -326,6 +325,7 @@ The 'good' example demonstrates how to document the Promise.
  */
 async function go (regionId, billingPeriod) {
 ```
+
 ## Page Title and Active NavBar Logic
 
 When working with `pageTitle` and `activeNavBar`, we follow the following conventions to maintain consistency and keep our code clean.
@@ -335,8 +335,6 @@ When working with `pageTitle` and `activeNavBar`, we follow the following conven
 The `pageTitle` should always be set in the presenter.
 
 This ensures that the `pageTitle` is dynamically generated alongside other data being worked out in the presenter. By centralising this logic in the presenter, we avoid duplication in the services, and maintain a single source of truth for dynamic page titles.
-
-### Good Example
 
 The following example demonstrates the correct way the presenter should return data:
 
@@ -361,8 +359,6 @@ The `activeNavBar` should always be set in the service that is called from the c
 
 Keeping the `activeNavBar` in the service reduces the logic in controllers.
 
-### Good Example
-
 The following example demonstrates the correct way the service should return data, when that data is being used to
 render a view. In this case, the `activeNavBar` is explicitly set within the service, while other data is handled and
 returned through the presenter:
@@ -378,10 +374,13 @@ async function go(id) {
   }
 }
 ```
+
 Note: We prefer to name the data fetched from the presenter as `formattedData` to clearly indicate that it has been
 processed and formatted for use in the view.
 
-### Bad Example
+The following example demonstrates the wrong way the service could return.  Notice that the presenter is returning
+`pageData` instead of `formattedData`. Additionally, the `pageTitle` is being returned from the service, whereas it
+should be returned by the presenter.
 
 ```javascript
 async function go(id) {
@@ -399,9 +398,7 @@ async function go(id) {
 
 Controllers should always return the view using the `pageData` object, which includes both the `pageTitle` and the `activeNavBar`, as well as any other required data.
 
-### Good Example
-
-The following example demonstrates the correct usage of `pageTitle` and `activeNavBar`:
+The following example demonstrates the correct way to set out the controllers:
 
 ```javascript
 async function reported(request, h) {
@@ -412,9 +409,7 @@ async function reported(request, h) {
 }
 ```
 
-### Bad Example
-
-The following example demonstrates the wrong usage of `pageTitle` and `activeNavBar`:
+The following example demonstrates the wrong way to set out the controller (returning `pageTitle` and `activeNavBar`):
 
 ```javascript
 async function reported(request, h) {

--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -364,7 +364,7 @@ Keeping the `activeNavBar` in the service reduces the logic in controllers.
 ### Good Example
 
 The following example demonstrates the correct way the service should return data, when that data is being used to
-render a view. In this case, the activeNavBar is explicitly set within the service, while other data is handled and
+render a view. In this case, the `activeNavBar` is explicitly set within the service, while other data is handled and
 returned through the presenter:
 
 ```javascript

--- a/coding_conventions.md
+++ b/coding_conventions.md
@@ -336,6 +336,24 @@ The `pageTitle` should always be set in the presenter.
 
 This ensures that the `pageTitle` is dynamically generated alongside other data being worked out in the presenter. By centralising this logic in the presenter, we avoid duplication in the services, and maintain a single source of truth for dynamic page titles.
 
+### Good Example
+
+The following example demonstrates the correct way the presenter should return data:
+
+```javascript
+function go(billLicence) {
+  const { id: billLicenceId, bill, licenceId, licenceRef, transactions } = billLicence
+
+  return {
+    accountNumber: bill.accountNumber,
+    billId: bill.id,
+    licenceId,
+    licenceRef,
+    pageTitle: `Transactions for ${licenceRef}`
+    scheme: bill.billRun.scheme,
+  }
+}
+```
 
 ### Active NavBar
 
@@ -343,6 +361,39 @@ The `activeNavBar` should always be set in the service that is called from the c
 
 Keeping the `activeNavBar` in the service reduces the logic in controllers.
 
+### Good Example
+
+The following example demonstrates the correct way the service should return data, when that data is being used to
+render a view. In this case, the activeNavBar is explicitly set within the service, while other data is handled and
+returned through the presenter:
+
+```javascript
+async function go(id) {
+  const billLicence = await FetchBillLicenceService.go(id)
+  const formattedData = ViewBillLicencePresenter.go(billLicence)
+
+  return {
+    activeNavBar: 'bill-runs',
+    ...formattedData
+  }
+}
+```
+Note: We prefer to name the data fetched from the presenter as formattedData to clearly indicate that it has been
+processed and formatted for use in the view.
+
+### Bad Example
+
+```javascript
+async function go(id) {
+  const billLicence = await FetchBillLicenceService.go(id)
+  const pageData = ViewBillLicencePresenter.go(billLicence)
+
+  return {
+    pageTitle: 'View a bill licence',
+    ...pageData
+  }
+}
+```
 
 ### Controller Implementation
 


### PR DESCRIPTION
As part of the migration of legacy pages, we’ve introduced a new convention for handling pageTitle and activeNavBar:

- pageTitle is now set in the presenter to handle dynamic logic. 
- activeNavBar is set in the service to keep controllers lightweight. 

This ensures a consistent structure across the codebase and improves maintainability.