### PR TITLE
Add query to verify licences 4 quarterly returns

### DIFF
--- a/queries/lics_needing_qtr_rtns.md
+++ b/queries/lics_needing_qtr_rtns.md
@@ -1,4 +1,4 @@
-# Water Company licences without return versions
+# Licences needing quarterly returns
 
 - **Business**
 - **2025-01-22**

--- a/queries/lics_with_no_return_versions.md
+++ b/queries/lics_with_no_return_versions.md
@@ -4,9 +4,9 @@
 - **2025-01-22**
 - [WATER-4880](https://eaflood.atlassian.net/browse/WATER-4880)
 
-> This report generates a list of all water companies (water undertakers) licences that do not have a return version.
+> This report generates a list of all water companies (water undertakers) that we will be migrating for quarterly returns.
 >
-> We want to have the business check each of this licences before we migrate all licences with return versions to
+> We want to have the business check each of these licences before we migrate all licences with return versions to
 > quarterly.
 
 ## Query

--- a/queries/lics_with_no_return_versions.md
+++ b/queries/lics_with_no_return_versions.md
@@ -1,0 +1,25 @@
+# Water Company licences without return versions
+
+- **Business**
+- **2025-01-22**
+- [WATER-4880](https://eaflood.atlassian.net/browse/WATER-4880)
+
+> This report generates a list of all water companies (water undertakers) licences that do not have a return version.
+>
+> We want to have the business check each of this licences before we migrate all licences with return versions to
+> quarterly.
+
+## Query
+
+```sql
+SELECT
+  l.licence_ref,
+  l.expired_date,
+  l.lapsed_date,
+  l.revoked_date,
+  l.regions->'regionalChargeArea' AS regionalChargeArea
+FROM public.licences l
+WHERE l.water_undertaker = true
+and l.id NOT IN (SELECT rv.licence_id FROM public.return_versions rv)
+```
+


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4880

To switch a licence to use quarterly return submissions, you have to create a new return version with the quarterly flag set. Rather than make our users do this manually, we intended to perform a one-off migration.

To do that, though, we need to know we're adding the new return version to the correct licences.

This change records an ad-hoc we created to find 'water undertaker' licences that 'quarterly-returns' applies to. It outputs when they end and whether they have an existing return version we can copy from. It also flags those we believe we need to create quarterly return versions for, and those we'll have a problem with if we try.

The output of this will be sent to the business to be verified, and used to correct the existing data ahead of the migration.