### PR TITLE
Update Licences with a primary user query

### DIFF
--- a/queries/lics_with_primary_users.md
+++ b/queries/lics_with_primary_users.md
@@ -1,18 +1,77 @@
 # Licences with a primary user
 
 - **Business**
-- **2023-06-27**
-- [WATER-4047](https://eaflood.atlassian.net/browse/WATER-4047)
+- **2025-03-20**
+- [WATER-4969](https://eaflood.atlassian.net/browse/WATER-4969)
 
-> [We need to] monitor the impact the new roles are having on Registration etc in each area[. N]ow we have no/limited location data but [we believe we] can use the licence numbers to merge with NALD data in Power BI and pull together the benchmarks.
+> We are looking to do a comms drop to registered users, possibly with a questionnaire or just as a request to get involved in User Research for the Water Availability Discovery.
 >
-> However to do this we need to provide [them] with a list of Licences that are registered in the Service, so essentially the ask is could we create a quick report of Registered licences, the email address of the Primary User, and if possible the NGR (National Grid Reference) code of the licence.  The NGR code isn’t completely necessary, as they should be able to get it from NALD unless it’s really easy to do.
+> There is also the need to be able to structure these by area, and industry so it feels like a bespoke report is required rather than re-using the [James report](https://eaflood.atlassian.net/browse/WATER-4047) (my initial plan).
 >
-> Therefore could we do a quick data dump of Registered Licence Numbers and their associated email address?
+>Therefore could we run a report against Production data and pull out:
+>
+> - email address of all “Primary Users”
+> - Account creation date
+> - Last logged in Date
+> - Secondary Use Description where there are multiple we could group on the most common or if there is 2 just pick one.
+> - EA Area
+> - email address of secondary users linked to licence.
+> - Licences registered to them
 
-This is the second time we have been asked to provide this data extract ([originally Jan 2023](https://eaflood.atlassian.net/browse/WATER-3872)). At that time we we analysed that extracting the NGR would be a massive task because of how it's been recorded in the system. That is still the case.
+> This can replace the regular report we run for James, and ticks off most of the improvements they have requested as well. Could this be run in before:  3/4/25.
+
+This is built on an earlier version we built (added for reference below). The extra information comes at a cost. The report takes a lot longer to run, and the results are no longer as 'neat'.
+
+Thanks to our work on rebuilding the returns notifications, we’ve gained a better understanding of how ‘users’ link to a licence. For example, a primary user can be linked to multiple licences as the primary user but could also be linked to others as a secondary user.
+
+This means a report where you mix users and licences is always going to feature both appearing to be duplicated.
+
+Added to that is the request for secondary purpose description. We’ve used just the current version of each licence, but even still, multiple purposes can be linked to a licence version, which means a licence can have multiple secondary purposes. Like secondary users, that extra criteria means even more results will be returned. To limit this, we’ve grouped them.
 
 ## Query
+
+```sql
+SELECT
+  e.entity_nm,
+  er."role",
+  least(u.date_created, e.created_at) AS created_on,
+  u.last_login,
+  licences.licence_ref,
+  licences.region_name,
+  licences.secondary_uses
+FROM (
+  SELECT
+    l.licence_ref,
+    r.display_name AS region_name,
+    (
+      SELECT array_agg(uses.description) FROM (
+        SELECT DISTINCT ps.description FROM water.licence_versions lv
+        INNER JOIN water.licence_version_purposes lvp ON lvp.licence_version_id = lv.licence_version_id
+        INNER JOIN water.purposes_secondary ps ON ps.purpose_secondary_id = lvp.purpose_secondary_id
+        WHERE lv.status = 'current' AND lv.licence_id = l.licence_id
+      ) uses
+    ) AS secondary_uses
+  FROM
+    water.licences l
+  INNER JOIN water.regions r ON
+    r.region_id = l.region_id
+) licences
+INNER JOIN crm.document_header dh ON
+  dh.system_external_id = licences.licence_ref
+INNER JOIN crm.entity_roles er ON
+  dh.company_entity_id = er.company_entity_id
+INNER JOIN crm.entity e ON
+  e.entity_id = er.entity_id
+INNER JOIN permit.licence pl ON
+  pl.licence_id = dh.system_internal_id::INTEGER
+INNER JOIN idm.users u ON
+  u.external_id = e.entity_id
+WHERE
+  er."role" IN ('primary_user', 'user_returns', 'agent')
+ORDER BY e.entity_nm, licences.licence_ref ASC;
+```
+
+## Original query
 
 ```sql
 SELECT


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4969

Back in March, we were asked to re-run the **Licences with a primary user** report but with some changes.

The business was looking to do a 'comms drop' to our registered users, which might include a questionnaire. They wanted to be able to group the information by area and industry, hence the need for a tweaked version.

After seeing the results, they asked if this could be used in place of the existing query in the future.

We were asked to rerun it, but we ran the original. That's when they reminded us they wanted the new version.

So, making this change to avoid a similar mistake in the future.