### PR TITLE
Add all users ad-hoc query

### DIFF
--- a/queries/all_users.md
+++ b/queries/all_users.md
@@ -1,0 +1,31 @@
+# All users
+
+- **Team**
+- **2026-07-21**
+- [WATER-5747](https://eaflood.atlassian.net/browse/WATER-5747)
+
+A bug was reported because someone was blocked creating an internal user because it turns out they already have an external account (see [WATER-5739](https://eaflood.atlassian.net/browse/WATER-5739)).
+
+There are scores of users with both internal and external accounts, and the legacy create user journey would have allowed this. It's just something we overlooked when we migrated the journey.
+
+We've fixed the bug, but it has led to questions being asked about the state of the user accounts. This was requested to inform that discussion.
+
+## Query
+
+```sql
+SELECT
+  u.user_name,
+  (CASE
+    WHEN u.application = 'water_admin' THEN 'internal'
+    WHEN u.application = 'water_vml' THEN 'external'
+    ELSE 'unknown'
+  END) AS user_type,
+  u.last_login,
+  u.enabled,
+  u.date_created
+FROM
+  idm.users u
+ORDER BY
+  u.user_name ASC,
+  u.application ASC;
+```


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5747

A bug was reported because someone was blocked from creating an internal user because it turns out they already have an external account (see [WATER-5739](https://eaflood.atlassian.net/browse/WATER-5739)).

There are scores of users with both internal and external accounts, and the legacy 'create user' journey would have allowed this. It's just something we overlooked when we migrated the journey.

We've fixed the bug, but it has raised questions about the state of user accounts. We were asked to provide a report on _all_ users and their status. This is the query that was used.

[WATER-5739]: https://eaflood.atlassian.net/browse/WATER-5739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ